### PR TITLE
Abstract tokenizer

### DIFF
--- a/test/test_vocab.py
+++ b/test/test_vocab.py
@@ -34,6 +34,8 @@ class TestVocabulary(unittest.TestCase):
         counts = [3, 2, 1, 1, 1, 2, 1, 1, 1, 2, 2]
         self.vocab = vocab.Vocabulary(ngrams)
         self.vocab_sw = vocab.Vocabulary(ngrams_sw, counts=counts)
+        self.vocab_whitespace = vocab.Vocabulary(
+            ngrams, tokenizer=lambda s: s.split())
 
     def test_word2id(self):
         self.assertEqual(self.vocab.word2id('city'), 2)
@@ -81,6 +83,11 @@ class TestVocabulary(unittest.TestCase):
         doc = 'New York City is in New York. Yay!'
         ids = self.vocab_sw.tokenize_ids(doc, remove_oov=False)
         self.assertEqual(list(ids), [8, 9, 10, 5, 4294967295])
+
+    def test_tokenize_underscore(self):
+        doc = 'new york a_b new _b_c_d_e_f'
+        self.assertEqual(self.vocab_whitespace.tokenize(doc),
+            ['new_york', 'new'])
 
     def test_random_id(self):
         np.random.seed(123)

--- a/vocab/cvocab.cc
+++ b/vocab/cvocab.cc
@@ -195,7 +195,7 @@ void Vocab::group_ngrams(std::vector<std::string> & tokens,
          it != tokens.end(); ++it)
     {
         // nothing to do if token was combined with another
-        if (*it == "")
+        if (it->empty())
             continue;
 
         vocab_ngram_t::iterator got_unigram = vocab[0].find(*it);

--- a/vocab/cvocab.cc
+++ b/vocab/cvocab.cc
@@ -190,13 +190,6 @@ void Vocab::group_ngrams(std::vector<std::string> & tokens,
     // remove all empty strings
     // If remove_oov is true, remove the out-of-vocabulary unigrams; otherwise,
     // add "OOV" to the return
-    /*
-    #include <algorithm>
-
-    std::string s = "a_b_c";
-    size_t n = std::count(s.begin(), s.end(), '_');
-    */
-
     ret.clear();
     for (std::vector<std::string>::iterator it = tokens.begin();
          it != tokens.end(); ++it)

--- a/vocab/cvocab.cc
+++ b/vocab/cvocab.cc
@@ -190,21 +190,38 @@ void Vocab::group_ngrams(std::vector<std::string> & tokens,
     // remove all empty strings
     // If remove_oov is true, remove the out-of-vocabulary unigrams; otherwise,
     // add "OOV" to the return
+    /*
+    #include <algorithm>
+
+    std::string s = "a_b_c";
+    size_t n = std::count(s.begin(), s.end(), '_');
+    */
+
     ret.clear();
     for (std::vector<std::string>::iterator it = tokens.begin();
          it != tokens.end(); ++it)
     {
+        // nothing to do if token was combined with another
+        if (*it == "")
+            continue;
+
         vocab_ngram_t::iterator got_unigram = vocab[0].find(*it);
         bool is_unigram = got_unigram != vocab[0].end();
-        std::size_t got_ngram = it->find("_");
-        bool is_ngram = got_ngram != std::string::npos;
-        if (*it != "")
+
+        // check if it's an n-gram
+        size_t n_underscore = std::count(it->begin(), it->end(), '_');
+        bool is_ngram = false;
+        if ((n_underscore > 0) && (n_underscore <= (max_ngram - 1)))
         {
-            if (is_unigram || is_ngram)
-                ret.push_back(*it);
-            else if (!remove_oov)
-                ret.push_back("OOV");
+            vocab_ngram_t::iterator got_ngram = vocab[n_underscore].find(*it);
+            is_ngram = got_ngram != vocab[n_underscore].end();
         }
+        
+        // add to list
+        if (is_unigram || is_ngram)
+            ret.push_back(*it);
+        else if (!remove_oov)
+            ret.push_back("OOV");
     }
 }
 

--- a/vocab/vocab.pyx
+++ b/vocab/vocab.pyx
@@ -233,7 +233,7 @@ cdef class Vocabulary:
                 fout.write(str(self._vocabptr.get_id2count(k)))
                 fout.write('\n')
 
-    def tokenize(self, string text, remove_oov=True):
+    def tokenize(self, text, remove_oov=True):
         """
         Tokenize an input string, grouping n-grams aggressively
 
@@ -246,7 +246,7 @@ cdef class Vocabulary:
         self._vocabptr.group_ngrams(tokens, ret, remove_oov)
         return ret
 
-    def tokenize_ids(self, string text, remove_oov=True):
+    def tokenize_ids(self, text, remove_oov=True):
         """
         Tokenize an input string, grouping n-grams aggressively. This function
         returns the token ids.

--- a/vocab/vocab.pyx
+++ b/vocab/vocab.pyx
@@ -33,12 +33,20 @@ def alpha_tokenize(s):
 
 
 def load_stopwords(stop_file=None):
+    '''
+    stop_file is None (use default list), or string (with filename) or
+        iterable
+    '''
     stopwords = set()
-    if stop_file:
+    if stop_file is None:
+        words = pkgutil.get_data('vocab', 'stop_words.txt').strip().split()
+    elif isinstance(stop_file, basestring):
+        # a file name
         with file(stop_file, 'r') as f:
             words = [line.rstrip() for line in f]
     else:
-        words = pkgutil.get_data('vocab', 'stop_words.txt').strip().split()
+        # assume to be iterable
+        words = stop_file
     for word in words:
         stopwords.add(word)
     return stopwords
@@ -107,14 +115,15 @@ cdef class Vocabulary:
         self._tokenizer = tokenizer
 
 
-    def __cinit__(self, vocab=None, tokenizer=None, stopword_file = None,
+    def __cinit__(self, vocab=None, tokenizer=None, stopword_file=None,
                   counts=None,
                   table_size=DEFAULT_TABLE_SIZE, power=DEFAULT_POWER):
         """
         vocab: vocabulary
         tokenizer: a tokenizer that splits strings into individual tokens
         stopword_file: file containing stopwords. If None, the default
-        stopword list is used.
+            stopword list is used.  If an iterable then gives
+            the list of stop words
         counts: word counts
         table_size: index lookup table size
         power: power used in building index lookup table
@@ -277,7 +286,7 @@ cdef class Vocabulary:
         return self._lookup_table.random_ids(num)
 
     @classmethod
-    def load(cls, fname, tokenizer=alpha_tokenize,
+    def load(cls, fname, tokenizer=alpha_tokenize, stopwords_file=None,
              table_size=DEFAULT_TABLE_SIZE, power=DEFAULT_POWER):
         """
         Create a Vocabulary instance, loading data from a file
@@ -309,4 +318,5 @@ cdef class Vocabulary:
                 wordid += 1
 
         return cls(vocab=vocab, tokenizer=tokenizer, counts=counts,
+                   stopword_file=stopwords_file,
                    table_size=table_size, power=power)


### PR DESCRIPTION
- Abstract the tokenizer to take python object and return list of strings (instead of string -> list of string)
- Fix a bug in `group_ngrams` when the input has underscores but the ngram isn't in the vocab
- allow more flexible specification of stop words
